### PR TITLE
Toggle js_errors key via env var JS_ERRORS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -135,6 +135,8 @@ You can use PhantomJS based Capybara driver Poltergeist driver.
 
       $ bundle exec rake poltergeist
 
+If you wish to disable JS errors you can add **JS_ERRORS=false** to the poltergeist key of cucumber.yml.
+
 ###Chrome Driver
 You can run your scenarios in Google Chrome
 

--- a/scaffold/accessibility/features/support/capybara.rb
+++ b/scaffold/accessibility/features/support/capybara.rb
@@ -26,7 +26,7 @@ Capybara.configure do |config|
 end
 Capybara.register_driver :poltergeist do |app|
   options = {
-    :js_errors => false,
+    :js_errors => (ENV['JS_ERRORS'] == "true" ? true : false),
     :timeout => 180,
     :debug => false
   }

--- a/scaffold/features/support/env.rb
+++ b/scaffold/features/support/env.rb
@@ -24,7 +24,7 @@ end
 
 Capybara.register_driver :poltergeist do |app|
   options = {
-    js_errors: true,
+    js_errors: (ENV['JS_ERRORS'] == "false" ? false : true),
     timeout: 120,
     debug: false,
     phantomjs_options: ['--load-images=no', '--disk-cache=false'],


### PR DESCRIPTION
Done to get green on the poltergeist example.

To enable set the poltergeist key in cucumber.yml to:
```yaml
poltergeist : DRIVER=poltergeist JS_ERRORS=false
```

Without the toggle I was getting:

```shell
Using the poltergeist and html profiles...
Feature: Google Search to explore BDDfire

  Scenario: View home page                     # features/bddfire.feature:4
    Given I am on "http://www.google.com"      # bddfire-2.0.8/lib/bddfire/web/web_steps.rb:2
      One or more errors were raised in the Javascript code on the page. If you don't care about these errors, you can ignore them by setting js_erro
rs: false in your Poltergeist configuration (see documentation for details).
      
      TypeError: undefined is not an object (evaluating 'google.jsc.x')
      TypeError: undefined is not an object (evaluating 'google.jsc.x')
          at http://www.google.co.uk/?gfe_rd=cr&dcr=0&ei=NQMPWtTUDsKN8QfHxpjYDw:44 (Capybara::Poltergeist::JavascriptError)
      features/bddfire.feature:5:in `Given I am on "http://www.google.com"'
    When I fill in "q" with the text "bddfire" # bddfire-2.0.8/lib/bddfire/web/web_steps.rb:6
    Then I should see "Sign in"                # bddfire-2.0.8/lib/bddfire/web/web_steps.rb:10

Failing Scenarios:
cucumber -p poltergeist -p html features/bddfire.feature:4 # Scenario: View home page

1 scenario (1 failed)
3 steps (1 failed, 2 skipped)
0m1.632s

```